### PR TITLE
Fixes according to metadata schema.

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension id="cache_management" status="released" xmlns="http://symphony-cms.com/schemas/extension/1.0">
+<extension id="cache_management" status="released" xmlns="http://getsymphony.com/schemas/extension/1.0">
 	<name>Cache Management</name>
 	<description>
 		Offers a backend page to manage (clear) Symphony's caches mechanism
@@ -16,9 +16,6 @@
 			<website>https://deuxhuithuit.com/</website>
 		</author>
 	</authors>
-	<dependencies>
-		<!-- None -->
-	</dependencies>
 	<releases>
 		<release version="1.3" date="2015-05-14" min="2.3.1" max="2.6.x">
 			- Added support for clearing Cacheable Datasource extension files (if installed)


### PR DESCRIPTION
There were some [lint](http://symphonyextensions.com/lint/) errors in the v1.3 extension meta xml file. There are still some errors on `types`, but the [specs](http://symphonyextensions.com/schemas/extension/1.0/#types) says you can have your own tags.

The [symphonyextensions.com](http://symphonyextensions.com) site does not fully acknowledge this extension releases, the latest version is not indicated in the lists, only on the [detail page](http://symphonyextensions.com/extensions/cache_management/). Maybe these changes will change something.

**Edit:** Corrected my commentary. My english is sometimes hard to understand, sorry.