### PR TITLE
Fix cache management

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -79,7 +79,7 @@
 		/**
 		 * Creates the table needed for the settings of the field
 		 */
-		public function update($previousVersion) {
+		public function update($previousVersion = false) {
 			return true;
 		}
 

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -17,6 +17,10 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.3.3" date="2016-08-11" min="2.3.1" max="2.6.x">
+			- Supported on PHP 7
+			- Fix database update to fit the parent method
+		</release>		
 		<release version="1.3.2" date="2015-12-22" min="2.3.1" max="2.6.x">
 			- Fix cron includes for newer Symphonies
 		</release>


### PR DESCRIPTION
Supported on PHP 7
- Needed to add $previousVersion = false.